### PR TITLE
README から除去された改行を再挿入

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ aplay ~/voice/おはようございます-1.wav
 
 ## 事例紹介
 
-**[VOICEVOX ENGINE SHARP](https://github.com/yamachu/VoicevoxEngineSharp) [@yamachu](https://github.com/yamachu)** ･･･ VOICEVOX ENGINE の C# 実装
-**[Node VOICEVOX Engine](https://github.com/y-chan/node-voicevox-engine) [@y-chan](https://github.com/y-chan)** ･･･ VOICEVOX ENGINE の Node.js/C++ 実装
+**[VOICEVOX ENGINE SHARP](https://github.com/yamachu/VoicevoxEngineSharp) [@yamachu](https://github.com/yamachu)** ･･･ VOICEVOX ENGINE の C# 実装  
+**[Node VOICEVOX Engine](https://github.com/y-chan/node-voicevox-engine) [@y-chan](https://github.com/y-chan)** ･･･ VOICEVOX ENGINE の Node.js/C++ 実装  
 
 ## ライセンス
 


### PR DESCRIPTION
#24 の変更時に[事例紹介の各項目末尾から空白を除去してしまいました](https://github.com/Hiroshiba/voicevox_core/commit/f3a8fce6b1dd6760a65f75ee6cfb41a351df2626#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L87-R102)（エディタの設定で自動除去されたものを、問題がないと思って放置してしまいました。不勉強で、Markdown において行末の２つ以上の空白は強制改行になることを知らなかったためです。よく調べると、[Markdown のオリジナル作者の記事](https://daringfireball.net/projects/markdown/syntax#p)にもこの仕様が明言されていました）。見栄えに影響するので元に戻すべきと思いPRしました。よろしくお願いいたします。