### PR TITLE
Pythonサンプルコード: 数値型の縮小変換により実行時例外が起きる問題の修正（32bit環境）

### DIFF
--- a/example/python/forwarder.py
+++ b/example/python/forwarder.py
@@ -146,6 +146,7 @@ class Forwarder:
             if p.phoneme in unvoiced_mora_phoneme_list:
                 f0_list[i] = 0
 
+        # use numpy.int32 as the number of repeats to avoid casting int64 to int32 in numpy internal
         phoneme = numpy.repeat(
             phoneme_list_s, numpy.round(phoneme_length * rate).astype(numpy.int32)
         )

--- a/example/python/forwarder.py
+++ b/example/python/forwarder.py
@@ -147,10 +147,10 @@ class Forwarder:
                 f0_list[i] = 0
 
         phoneme = numpy.repeat(
-            phoneme_list_s, numpy.round(phoneme_length * rate).astype(numpy.int64)
+            phoneme_list_s, numpy.round(phoneme_length * rate).astype(numpy.int32)
         )
         f0 = numpy.repeat(
-            f0_list, numpy.round(phoneme_length_sa * rate).astype(numpy.int64)
+            f0_list, numpy.round(phoneme_length_sa * rate).astype(numpy.int32)
         )
 
         # forward decode


### PR DESCRIPTION
## 内容

ONNX版コアのRaspberry Pi（32bit armv7l hardware float環境）向けのビルドを試しています。

そこで、サンプルコード実行時、`example/python/forwarder.py` 内の`numpy.repeat`の呼び出しで`TypeError: Cannot cast array data from dtype('int64') to dtype('int32') according to the rule 'safe'`というエラーが発生しました。

- https://numpy.org/devdocs/reference/generated/numpy.repeat.html

このPRは、`numpy.repeat`の繰り返し回数`repeats`として`numpy.int64`型を渡していた部分を`numpy.int32`型に変更し、numpy内部で縮小変換（int64→int32の変換）させないようにすることで、実行時例外が起きないようにします。

~~32bit環境か64bit環境かによって変わるかもしれないので、こちらで検証したらドラフトを外します。
変更が必要であれば、このPRのまま対応するつもりです。~~
→ 64bit環境でもint32で動作しました。


Raspberry Pi 4B実機でのログ

<details>

- 使用したONNXRuntimeバイナリ: https://github.com/aoirint/onnxruntime-arm-build/releases/tag/v1.8.2-8

```shell
$ pip3 show numpy --version
Name: numpy
Version: 1.21.3

$ python3 ../../example/python/run.py --text "これは本当に実行できているんですか" --speaker_id 1
Traceback (most recent call last):
  File "/home/pi/.local/lib/python3.7/site-packages/numpy/core/fromnumeric.py", line 57, in _wrapfunc
    return bound(*args, **kwds)
TypeError: Cannot cast array data from dtype('int64') to dtype('int32') according to the rule 'safe'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "../../example/python/run.py", line 48, in <module>
    run(**vars(parser.parse_args()))
  File "../../example/python/run.py", line 32, in run
    f0_correct=f0_correct,
  File "/home/pi/git/voicevox_core/example/python/forwarder.py", line 150, in forward
    phoneme_list_s, numpy.round(phoneme_length * rate).astype(numpy.int64)
  File "<__array_function__ internals>", line 6, in repeat
  File "/home/pi/.local/lib/python3.7/site-packages/numpy/core/fromnumeric.py", line 479, in repeat
    return _wrapfunc(a, 'repeat', repeats, axis=axis)
  File "/home/pi/.local/lib/python3.7/site-packages/numpy/core/fromnumeric.py", line 66, in _wrapfunc
    return _wrapit(obj, method, *args, **kwds)
  File "/home/pi/.local/lib/python3.7/site-packages/numpy/core/fromnumeric.py", line 43, in _wrapit
    result = getattr(asarray(obj), method)(*args, **kwds)
TypeError: Cannot cast array data from dtype('int64') to dtype('int32') according to the rule 'safe'
```

</details>
