### PR TITLE
ONNX版自動ビルド: Release用Artifactが入れ子のzipになっていたのを解消

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,7 +228,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          path: core.zip
+          name: core
+          path: release/*
 
       - name: Upload to Release
         if: env.SKIP_UPLOADING_RELEASE_ASSET == '0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,7 +220,7 @@ jobs:
 
           cp core.h release/
 
-          echo ${{ env.BUILD_IDENTIFIER }} > release/VERSION
+          echo "${{ env.BUILD_IDENTIFIER }}" > release/VERSION
 
           cd release/
           zip -r ../core.zip *


### PR DESCRIPTION
## 内容

Artifactに自動ビルドの成果物をアップロードする際、
core.zipに圧縮してからアップロードしていたため、
Artifactのzipの中にcore.zipが入った、入れ子の状態になっていました。

このPRは、入れ子を解消し、core.zipを直接Artifact一覧からダウンロードできるようにします。

- 現在のArtifact（artifact） https://github.com/Hiroshiba/voicevox_core/actions/runs/1413653469
- 解消したArtifact（core） https://github.com/aoirint/voicevox_core/actions/runs/1414117128
